### PR TITLE
added NPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+index.js
+node_modules

--- a/npm-build.js
+++ b/npm-build.js
@@ -1,0 +1,45 @@
+import _ from 'lodash'
+import fs from 'fs'
+import path from 'path'
+import Promise from 'bluebird'
+
+Promise.promisifyAll(fs)
+
+function getProvinces () {
+  return fs.readdirAsync('./countries')
+    .then(countryFiles => {
+      let props = _.chain(countryFiles)
+      .map(countryFile => {
+        let file = path.basename(countryFile, path.extname(countryFiles))
+        return [file, fs.readFileAsync(`./countries/${countryFile}`, 'utf8').then(JSON.parse)]
+      })
+      .zipObject()
+      .value()
+      return Promise.props(props)
+    })
+}
+
+function getCountries () {
+  return fs.readFileAsync('./countries.json', 'utf8').then(JSON.parse)
+}
+
+function assemble () {
+  return Promise.props({
+    'provinces': getProvinces(),
+    'countries': getCountries(),
+  })
+}
+
+function prettyPrintJSON (json) {
+  return JSON.stringify(json, null, 2)
+}
+
+function writeFile () {
+  return assemble()
+    .then(data => {
+      return fs.writeFileAsync('./index.js', prettyPrintJSON(data))
+    })
+}
+
+writeFile()
+.catch(console.error.bind(console))

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "countries-provinces",
+  "version": "1.0.0",
+  "description": "Countries and Provinces / States / Regions",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "babel-node npm-build.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/astockwell/countries-and-provinces-states-regions.git"
+  },
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/astockwell/countries-and-provinces-states-regions/issues"
+  },
+  "homepage": "https://github.com/astockwell/countries-and-provinces-states-regions#readme",
+  "devDependencies": {
+    "bluebird": "^3.2.1",
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.4.5",
+    "babel-preset-es2015": "^6.3.13"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  }
+}


### PR DESCRIPTION
Hey! 

I was thinking about using something like this with node.js.

This PR adds a `package.json` file and a `npm-build.js` script that creates a static `./index.js` (a mega json object) file to be built when someone runs `npm install counties-provinces` (didn't claim yet).

Thoughts appreciated :)
